### PR TITLE
NEW Add plugin to re-dispatch missing stock item event, observer to handle it

### DIFF
--- a/Model/ResourceModel/Stock/Plugin.php
+++ b/Model/ResourceModel/Stock/Plugin.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace AltoLabs\Snappic\Model\ResourceModel\Stock;
+
+use Magento\CatalogInventory\Model\ResourceModel\Stock;
+
+class Plugin
+{
+    /**
+     * @var \Magento\Framework\Event\ManagerInterface
+     */
+    protected $eventManager;
+
+    /**
+     * @param \Magento\Framework\Event\ManagerInterface $eventManager
+     */
+    public function __construct(
+        \Magento\Framework\Event\ManagerInterface $eventManager
+    ) {
+        $this->eventManager = $eventManager;
+    }
+
+    /**
+     * The stock item correctItemsQty method is not observable at the moment, so using a plugin to dispatch a
+     * custom event
+     *
+     * https://github.com/magento/magento2/issues/4857
+     *
+     * @param Stock $item
+     * @param callable $proceed
+     * @param array $items
+     * @param int $websiteId
+     * @param string $operator
+     */
+    public function aroundCorrectItemsQty(Stock $subject, callable $proceed, array $items, $websiteId, $operator)
+    {
+        $proceed($items, $websiteId, $operator);
+
+        if (empty($items)) {
+            return;
+        }
+
+        $this->eventManager->dispatch(
+            'altolabs_catalog_product_stock_save_after',
+            ['product_ids' => array_keys($items)]
+        );
+    }
+}

--- a/Observer/HandleStockChange.php
+++ b/Observer/HandleStockChange.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace AltoLabs\Snappic\Observer;
+
+use Magento\Framework\Event\ObserverInterface;
+
+class HandleStockChange extends AbstractObserver implements ObserverInterface
+{
+    /**
+     * @param \Magento\Framework\Event\Observer $observer
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        $this->handleProductChanges((array) $observer->getEvent()->getProductIds());
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -3,7 +3,11 @@
     <type name="Magento\Catalog\Model\Product\Action">
         <plugin name="altolabs_snappic_product_action_plugin"
             type="AltoLabs\Snappic\Model\Product\Action\Plugin"
-            sortOrder="100"
-            disabled="false" />
+            sortOrder="100" />
+    </type>
+    <type name="Magento\CatalogInventory\Model\ResourceModel\Stock">
+        <plugin name="altolabs_snappic_stock_plugin"
+            type="AltoLabs\Snappic\Model\ResourceModel\Stock\Plugin"
+            sortOrder="100" />
     </type>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -4,4 +4,8 @@
         <observer name="altolabs_snappic_observer_afterorderplace"
             instance="AltoLabs\Snappic\Observer\AfterOrderPlace" />
     </event>
+    <event name="altolabs_catalog_product_stock_save_after">
+        <observer name="altolabs_snappic_observer_stockchangeobserver"
+            instance="AltoLabs\Snappic\Observer\HandleStockChange" />
+    </event>
 </config>


### PR DESCRIPTION
Adds a plugin to listen to the "correctItemsQty" stock resource model method, gather updated product IDs from it and dispatch a generic event which an observer listens to to notify Snappic when product stock levels change.